### PR TITLE
Compiling Cadmium Cell-DEVS models

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,4 +13,8 @@ make
 make install
 
 # compile Cadmium Cell-DEVS models TODO
-cd ../../CellDEVS_models
+cd ../../CellDEVS_models/tutorial
+mkdir build
+cd build
+cmake ..
+make


### PR DESCRIPTION
Just a minor change to `setup.sh`. Now, it automatically compiles all the Cell-DEVS models for Cadmium